### PR TITLE
Add commands: `help`, `commands` 

### DIFF
--- a/internal/commands/debug.go
+++ b/internal/commands/debug.go
@@ -7,19 +7,20 @@ import (
 	"github.com/the-sanctuary/waddles/pkg/cmd"
 )
 
+//Debug debug command
 var Debug *cmd.Command = &cmd.Command{
 	Name:        "debug",
 	Aliases:     []string{"dbg"},
 	Description: "bot debug interface",
 	Usage:       "",
 	HideInHelp:  true,
-	SubCommands: []*cmd.Command{DebugDumpPerms, DebugListPerms},
+	SubCommands: []*cmd.Command{debugDumpPerms, debugListPerms},
 	Handler: func(c *cmd.Context) {
 		c.ReplyHelp()
 	},
 }
 
-var DebugListPerms *cmd.Command = &cmd.Command{
+var debugListPerms *cmd.Command = &cmd.Command{
 	Name:        "listPerms",
 	Aliases:     []string{""},
 	Description: "lists text representation of permission system",
@@ -66,7 +67,7 @@ var DebugListPerms *cmd.Command = &cmd.Command{
 	},
 }
 
-var DebugDumpPerms *cmd.Command = &cmd.Command{
+var debugDumpPerms *cmd.Command = &cmd.Command{
 	Name:        "dumpPerms",
 	Aliases:     []string{""},
 	Description: "dumps raw PermissionSystem struct",

--- a/internal/commands/debug.go
+++ b/internal/commands/debug.go
@@ -4,26 +4,27 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/the-sanctuary/waddles/pkg/command"
+	"github.com/the-sanctuary/waddles/pkg/cmd"
 )
 
-var Debug *command.Command = &command.Command{
+var Debug *cmd.Command = &cmd.Command{
 	Name:        "debug",
 	Aliases:     []string{"dbg"},
 	Description: "bot debug interface",
 	Usage:       "",
-	SubCommands: []*command.Command{DebugDumpPerms, DebugListPerms},
-	Handler: func(c *command.Context) {
+	HideInHelp:  true,
+	SubCommands: []*cmd.Command{DebugDumpPerms, DebugListPerms},
+	Handler: func(c *cmd.Context) {
 		c.ReplyHelp()
 	},
 }
 
-var DebugListPerms *command.Command = &command.Command{
+var DebugListPerms *cmd.Command = &cmd.Command{
 	Name:        "listPerms",
 	Aliases:     []string{""},
 	Description: "lists text representation of permission system",
 	Usage:       "",
-	Handler: func(c *command.Context) {
+	Handler: func(c *cmd.Context) {
 		tre := &c.Router.PermSystem.Tree
 
 		var lines []string
@@ -65,12 +66,12 @@ var DebugListPerms *command.Command = &command.Command{
 	},
 }
 
-var DebugDumpPerms *command.Command = &command.Command{
+var DebugDumpPerms *cmd.Command = &cmd.Command{
 	Name:        "dumpPerms",
 	Aliases:     []string{""},
 	Description: "dumps raw PermissionSystem struct",
 	Usage:       "",
-	Handler: func(c *command.Context) {
+	Handler: func(c *cmd.Context) {
 		tre := &c.Router.PermSystem.Tree
 		c.ReplyStringf("```%+v```", tre)
 	},

--- a/internal/commands/help.go
+++ b/internal/commands/help.go
@@ -1,0 +1,52 @@
+package commands
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/the-sanctuary/waddles/pkg/cmd"
+)
+
+var Help *cmd.Command = &cmd.Command{
+	Name:        "help",
+	Aliases:     []string{"h"},
+	Description: "help text",
+	Usage:       "help",
+	Handler: func(c *cmd.Context) {
+		c.ReplyStringf("Please use `%scommands` to view a list of commands.", c.Router.Config.Wadl.Prefix)
+	},
+}
+
+var Commands *cmd.Command = &cmd.Command{
+	Name:        "commands",
+	Aliases:     []string{"c"},
+	Description: "list of commands",
+	Usage:       "commands",
+	SubCommands: []*cmd.Command{},
+	Handler: func(c *cmd.Context) {
+		cmds := c.Router.Commands
+		builder := strings.Builder{}
+
+		builder.WriteString("```\n")
+
+		rBuildHelp(c, &builder, cmds, 0)
+
+		builder.WriteString("```")
+		c.ReplyString(builder.String())
+	},
+}
+
+func rBuildHelp(c *cmd.Context, builder *strings.Builder, cmds []*cmd.Command, depth int) {
+	for _, cmd := range cmds {
+		if cmd.HideInHelp {
+			continue
+		}
+		indent := strings.Repeat("  ", depth)
+		helpText := cmd.SPrintHelp()
+
+		fmt.Fprintf(builder, "%s ♦ %s\n", indent, helpText)
+		if cmd.HasSubcommands() {
+			rBuildHelp(c, builder, cmd.SubCommands, depth+1)
+		}
+	}
+}

--- a/internal/commands/nitro.go
+++ b/internal/commands/nitro.go
@@ -1,14 +1,16 @@
 package commands
 
-import "github.com/the-sanctuary/waddles/pkg/command"
+import (
+	"github.com/the-sanctuary/waddles/pkg/cmd"
+)
 
-var Nitro *command.Command = &command.Command{
+var Nitro *cmd.Command = &cmd.Command{
 	Name:        "nitro",
 	Aliases:     []string{"n"},
 	Description: " access your perks as a server nitro booster",
-	Usage:       "nitro channel ",
-	SubCommands: []*command.Command{NitroChannel},
-	Handler: func(c *command.Context) {
+	Usage:       "nitro (channel)",
+	SubCommands: []*cmd.Command{NitroChannel},
+	Handler: func(c *cmd.Context) {
 		c.ReplyHelp()
 	},
 }

--- a/internal/commands/nitro_channel.go
+++ b/internal/commands/nitro_channel.go
@@ -5,17 +5,18 @@ import (
 
 	"github.com/bwmarrin/discordgo"
 	"github.com/the-sanctuary/waddles/internal/model"
-	"github.com/the-sanctuary/waddles/pkg/command"
+	"github.com/the-sanctuary/waddles/pkg/cmd"
+
 	"github.com/the-sanctuary/waddles/pkg/util"
 )
 
-var NitroChannel *command.Command = &command.Command{
+var NitroChannel *cmd.Command = &cmd.Command{
 	Name:        "channel",
 	Aliases:     *&[]string{"c"},
 	Description: "control your voice channel",
 	Usage:       "channel (register|release)",
-	SubCommands: []*command.Command{NitroChannelRegister, NitroChannelRelease},
-	Handler: func(c *command.Context) {
+	SubCommands: []*cmd.Command{NitroChannelRegister, NitroChannelRelease},
+	Handler: func(c *cmd.Context) {
 		//Check to see if a user already has a channel registered
 		var chann model.NitroUserChannel
 		c.DB().Where(&model.NitroUserChannel{UserID: c.Message.Author.ID}).First(&chann)
@@ -28,12 +29,12 @@ var NitroChannel *command.Command = &command.Command{
 	},
 }
 
-var NitroChannelRelease *command.Command = &command.Command{
+var NitroChannelRelease *cmd.Command = &cmd.Command{
 	Name:        "release",
 	Aliases:     *&[]string{"rl"},
 	Description: "release your voice channel",
 	Usage:       "release",
-	Handler: func(c *command.Context) {
+	Handler: func(c *cmd.Context) {
 		//Check to see if a user already has a channel registered
 		var chann model.NitroUserChannel
 		c.DB().Where(&model.NitroUserChannel{UserID: c.Message.Author.ID}).First(&chann)
@@ -50,12 +51,12 @@ var NitroChannelRelease *command.Command = &command.Command{
 	},
 }
 
-var NitroChannelRegister *command.Command = &command.Command{
+var NitroChannelRegister *cmd.Command = &cmd.Command{
 	Name:        "register",
 	Aliases:     *&[]string{"r"},
 	Description: "register your voice channel",
 	Usage:       "register <name>",
-	Handler: func(c *command.Context) {
+	Handler: func(c *cmd.Context) {
 		if len(c.Args) < 1 {
 			c.ReplyString("You must name supply a name for your channel")
 			return

--- a/internal/commands/ping.go
+++ b/internal/commands/ping.go
@@ -3,27 +3,28 @@ package commands
 import (
 	"strconv"
 
-	"github.com/the-sanctuary/waddles/pkg/command"
+	"github.com/the-sanctuary/waddles/pkg/cmd"
+
 	"github.com/the-sanctuary/waddles/pkg/util"
 )
 
 //Ping command
-var Ping *command.Command = &command.Command{
+var Ping *cmd.Command = &cmd.Command{
 	Name:        "ping",
 	Aliases:     *&[]string{"pong"},
 	Description: "This pongs your ping(pong)!",
 	Usage:       "ping [count <num>]",
-	Handler: func(c *command.Context) {
+	Handler: func(c *cmd.Context) {
 		c.ReplyString("Pong!")
 	},
-	SubCommands: []*command.Command{PingCount},
+	SubCommands: []*cmd.Command{PingCount},
 }
 
-var PingCount *command.Command = &command.Command{
+var PingCount *cmd.Command = &cmd.Command{
 	Name:        "count",
 	Description: "how many times to reply with pong",
-	Usage:       "ping",
-	Handler: func(c *command.Context) {
+	Usage:       "count <num>",
+	Handler: func(c *cmd.Context) {
 		if len(c.Args) >= 1 {
 			n, err := strconv.Atoi(c.Args[0])
 

--- a/internal/commands/purge.go
+++ b/internal/commands/purge.go
@@ -4,16 +4,17 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/the-sanctuary/waddles/pkg/command"
+	"github.com/the-sanctuary/waddles/pkg/cmd"
+
 	"github.com/the-sanctuary/waddles/pkg/util"
 )
 
 //Purge command
-var Purge *command.Command = &command.Command{
+var Purge *cmd.Command = &cmd.Command{
 	Name:        "purge",
 	Description: "Remove message history.",
 	Usage:       "purge [num]",
-	Handler: func(c *command.Context) {
+	Handler: func(c *cmd.Context) {
 		if len(c.Args) >= 1 {
 			n, err := strconv.Atoi(c.Args[0])
 			if util.DebugError(err) {

--- a/internal/commands/uptime.go
+++ b/internal/commands/uptime.go
@@ -3,15 +3,16 @@ package commands
 import (
 	"time"
 
-	"github.com/the-sanctuary/waddles/pkg/command"
+	"github.com/the-sanctuary/waddles/pkg/cmd"
+
 	"github.com/the-sanctuary/waddles/pkg/util"
 )
 
-var Uptime *command.Command = &command.Command{
+var Uptime *cmd.Command = &cmd.Command{
 	Name:        "uptime",
 	Description: "the uptime of the bot",
 	Usage:       "uptime",
-	Handler: func(c *command.Context) {
+	Handler: func(c *cmd.Context) {
 		c.ReplyStringf("Current Bot Time: `%s`", time.Now().Format(time.RFC1123Z))
 		c.ReplyStringf("Uptime: `%s`", util.Uptime().Round(time.Second))
 	},

--- a/pkg/cfg/cfg_test.go
+++ b/pkg/cfg/cfg_test.go
@@ -1,1 +1,19 @@
 package cfg
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_GetConfigFileLocation(t *testing.T) {
+	config1 := Config{
+		configDir: "/foo/bar/",
+	}
+	config2 := Config{
+		configDir: "/foo/bar/haz",
+	}
+
+	assert.Equal(t, "/foo/bar/config1.toml", config1.GetConfigFileLocation("config1.toml"))
+	assert.Equal(t, "/foo/bar/haz/config2.toml", config2.GetConfigFileLocation("config2.toml"))
+}

--- a/pkg/cfg/config.go
+++ b/pkg/cfg/config.go
@@ -25,6 +25,10 @@ type Config struct {
 			ParentID string `toml:"parent-id" comment:"Discord catagory ID for channels to be managed under"`
 		} `toml:"booster-channel" comment:"server booster personal channel options"`
 	} `toml:"nitro" comment:"perks related to being a server booster"`
+
+	Permissions struct {
+		UserOverride []string `toml:"bypass-users" comment:"list of user IDs who bypass the permission's system (useful for testing)"`
+	} `toml:"permissions" comment:"settings related to the permissions system"`
 }
 
 //GetConfigFileLocation returns the full path of the requested configFile

--- a/pkg/cfg/config.go
+++ b/pkg/cfg/config.go
@@ -1,5 +1,7 @@
 package cfg
 
+import "path"
+
 // Config holds bot config information
 type Config struct {
 	configDir string
@@ -33,5 +35,5 @@ type Config struct {
 
 //GetConfigFileLocation returns the full path of the requested configFile
 func (config Config) GetConfigFileLocation(configFile string) string {
-	return config.configDir + configFile
+	return path.Clean(config.configDir + "/" + configFile)
 }

--- a/pkg/cmd/command.go
+++ b/pkg/cmd/command.go
@@ -1,6 +1,10 @@
-package command
+package cmd
 
-import "github.com/the-sanctuary/waddles/pkg/permissions"
+import (
+	"fmt"
+
+	"github.com/the-sanctuary/waddles/pkg/permissions"
+)
 
 //Command  is the struct that holds information about a command
 type Command struct {
@@ -8,7 +12,9 @@ type Command struct {
 	Aliases     []string
 	Description string
 	//Usage format: http://docopt.org/
-	Usage       string
+	Usage string
+	//HideInHelp whether or not this should be hidden from the help command.
+	HideInHelp  bool
 	SubCommands []*Command
 	Handler     ContextExecutor
 }
@@ -37,4 +43,9 @@ func (c *Command) GeneratePermissionNode(permSystem *permissions.PermissionSyste
 			subCmd.GeneratePermissionNode(permSystem, newBaseNode+".")
 		}
 	}
+}
+
+//SPrintHelp returns the formatted help text string
+func (c *Command) SPrintHelp() string {
+	return fmt.Sprintf("%s - %s", c.Usage, c.Description)
 }

--- a/pkg/cmd/command_test.go
+++ b/pkg/cmd/command_test.go
@@ -1,4 +1,4 @@
-package command
+package cmd
 
 import (
 	"testing"

--- a/pkg/cmd/context.go
+++ b/pkg/cmd/context.go
@@ -1,4 +1,4 @@
-package command
+package cmd
 
 import (
 	"fmt"

--- a/pkg/cmd/router.go
+++ b/pkg/cmd/router.go
@@ -1,7 +1,8 @@
-package command
+package cmd
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/bwmarrin/discordgo"
@@ -42,6 +43,7 @@ func (r *Router) SetupPermissions() {
 
 //RegisterCommands adds a command(s) to the Router
 func (r *Router) RegisterCommands(cmds ...*Command) {
+	sort.Slice(cmds, func(i, j int) bool { return cmds[i].Name < cmds[j].Name })
 	for _, c := range cmds {
 		r.Commands = append(r.Commands, c)
 	}
@@ -80,7 +82,7 @@ func (r *Router) Handler() func(*discordgo.Session, *discordgo.MessageCreate) {
 			ctx := buildContext(r, session, message, deepestCmd, args)
 
 			if !r.userHasCorrectPermissions(session, message.Author, node) {
-				ctx.ReplyStringf("You don't have the required permission node `%s` for this command.", node)
+				ctx.ReplyStringf("You don't have the required permission node `%s` for this cmd.", node)
 				return
 			}
 
@@ -89,18 +91,32 @@ func (r *Router) Handler() func(*discordgo.Session, *discordgo.MessageCreate) {
 			//Update UserActivity entry's CommandCount
 			var ua model.UserActivity
 			tx := db.Instance.DB.Where(&model.UserActivity{UserID: message.Author.ID}).FirstOrCreate(&ua)
-			util.DebugError(tx.Error)
+			if util.DebugError(tx.Error) {
+				log.Error().Err(tx.Error).Msg("An error occured.")
+			}
 			ua.CommandCount++
 			db.Instance.DB.Save(&ua)
 		}
 	}
 }
 
-func (r Router) userHasCorrectPermissions(session *discordgo.Session, user *discordgo.User, nodeIdentifier string) bool {
+func (r *Router) userHasCorrectPermissions(session *discordgo.Session, user *discordgo.User, nodeIdentifier string) bool {
 	gm, err := session.GuildMember(r.Config.Wadl.GuildID, user.ID)
-	util.DebugError(err)
+	if util.DebugError(err) {
+		log.Error().Err(err).Msg("An error has occurred.")
+		return false
+	}
+
+	if r.userHasBypassPermissions(user) {
+		log.Debug().Msgf("User %s is on the permission bypass list.", user.ID)
+		return true
+	}
 
 	return r.PermSystem.UserHasPermissionNode(gm, nodeIdentifier)
+}
+
+func (r *Router) userHasBypassPermissions(user *discordgo.User) bool {
+	return util.SliceContains(r.Config.Permissions.UserOverride, user.ID)
 }
 
 //Finds and returns the deepest subcommand for a given command and arg slice

--- a/pkg/cmd/router.go
+++ b/pkg/cmd/router.go
@@ -108,7 +108,7 @@ func (r *Router) userHasCorrectPermissions(session *discordgo.Session, user *dis
 	}
 
 	if r.userHasBypassPermissions(user) {
-		log.Debug().Msgf("User %s is on the permission bypass list.", user.ID)
+		log.Debug().Msgf("User %s (%s) is on the permission bypass list.", user.ID, user.Username)
 		return true
 	}
 

--- a/pkg/cmd/router_test.go
+++ b/pkg/cmd/router_test.go
@@ -1,4 +1,4 @@
-package command
+package cmd
 
 import (
 	"testing"

--- a/pkg/permissions/permissions_test.go
+++ b/pkg/permissions/permissions_test.go
@@ -9,13 +9,13 @@ import (
 )
 
 func BasePermissionSystem() PermissionSystem {
-	// router := command.Router{
+	// router := cmd.Router{
 	// 	Prefix: "~",
 	// }
 
 	// router.RegisterCommands(
-	// 	&command.Command{Name: "test1node1"},
-	// 	&command.Command{Name: "test2node1"},
+	// 	&cmd.Command{Name: "test1node1"},
+	// 	&cmd.Command{Name: "test2node1"},
 	// )
 
 	permSystem := PermissionSystem{
@@ -64,26 +64,26 @@ const tomlBytesAll = (`
 
 func Test_generateNodesFromCommand(t *testing.T) {
 	t.Skip()
-	// testCmdSub1 := &command.Command{
+	// testCmdSub1 := &cmd.Command{
 	// 	Name:    "sub1",
-	// 	Handler: func(c *command.Context) {},
+	// 	Handler: func(c *cmd.Context) {},
 	// }
 
-	// testCmdSub21 := &command.Command{
+	// testCmdSub21 := &cmd.Command{
 	// 	Name:    "sub21",
-	// 	Handler: func(c *command.Context) {},
+	// 	Handler: func(c *cmd.Context) {},
 	// }
 
-	// testCmdSub2 := &command.Command{
+	// testCmdSub2 := &cmd.Command{
 	// 	Name:        "sub2",
-	// 	Handler:     func(c *command.Context) {},
-	// 	SubCommands: []*command.Command{testCmdSub21},
+	// 	Handler:     func(c *cmd.Context) {},
+	// 	SubCommands: []*cmd.Command{testCmdSub21},
 	// }
 
-	// testCmd := &command.Command{
+	// testCmd := &cmd.Command{
 	// 	Name:        "testcmd",
-	// 	Handler:     func(c *command.Context) {},
-	// 	SubCommands: []*command.Command{testCmdSub1, testCmdSub2},
+	// 	Handler:     func(c *cmd.Context) {},
+	// 	SubCommands: []*cmd.Command{testCmdSub1, testCmdSub2},
 	// }
 
 	// assert.NotNil(t, testCmd)

--- a/pkg/waddles/waddles.go
+++ b/pkg/waddles/waddles.go
@@ -6,7 +6,8 @@ import (
 	"github.com/the-sanctuary/waddles/internal/commands"
 	"github.com/the-sanctuary/waddles/internal/handlers"
 	"github.com/the-sanctuary/waddles/pkg/cfg"
-	"github.com/the-sanctuary/waddles/pkg/command"
+	"github.com/the-sanctuary/waddles/pkg/cmd"
+
 	"github.com/the-sanctuary/waddles/pkg/db"
 	"github.com/the-sanctuary/waddles/pkg/handler"
 	"github.com/the-sanctuary/waddles/pkg/permissions"
@@ -17,7 +18,7 @@ import (
 type Waddles struct {
 	//Global Config
 	Config   *cfg.Config
-	Router   *command.Router
+	Router   *cmd.Router
 	Database *db.WadlDB
 	Session  *discordgo.Session
 }
@@ -43,7 +44,7 @@ func (w *Waddles) Run() {
 
 	permSystem := permissions.BuildPermissionSystem(w.Config.GetConfigFileLocation("permissions.toml"))
 
-	r := command.BuildRouter(w.Database, &permSystem, w.Config)
+	r := cmd.BuildRouter(w.Database, &permSystem, w.Config)
 
 	r.RegisterCommands(
 		commands.Ping,
@@ -51,6 +52,8 @@ func (w *Waddles) Run() {
 		commands.Uptime,
 		commands.Nitro,
 		commands.Debug,
+		commands.Commands,
+		commands.Help,
 	)
 
 	r.SetupPermissions()


### PR DESCRIPTION
- adds "help" and "commands"
- moves pkg/command to pkg/cmd
- adds bypass of permissions system in config file
- cmd.Command.HideInHelp will hide a command and all of its subcommands from the "commands" list